### PR TITLE
fix bug where preloading buffer would cut off the first letter of eve…

### DIFF
--- a/noise.nim
+++ b/noise.nim
@@ -264,6 +264,7 @@ when promptPreloadBuffer:
           inc pos
           if c notin WhiteSpace: break
         temp.add ' '
+        temp.add c
       else:
         temp.add c
         inc pos


### PR DESCRIPTION
…ry word that followed whitespace