### PR TITLE
Add CTRL-X as meta key code

### DIFF
--- a/noise.nim
+++ b/noise.nim
@@ -26,6 +26,7 @@ when promptBasic:
       ktNone
       ktCtrlC
       ktCtrlD
+      ktCtrlX
 
     EditMode = enum
       editOK

--- a/noise/editorImpl.nim
+++ b/noise/editorImpl.nim
@@ -324,6 +324,10 @@ proc basicEditing(self: var Noise, c: char32): EditMode {.cdecl.} =
     else:
       result = editExit
     self.keyType = ktCtrlD
+  of ctrlChar('X'):
+    # ctrl-X, for custom implementations
+    self.keyType = ktCtrlX
+    result = editExit
   of ctrlChar('J'), ctrlChar('M'):
     # ctrl-J/linefeed/newline, accept line
     # ctrl-M/return/enter


### PR DESCRIPTION
This adds CTRL-X as an additional meta key type to allow for custom implementations of emacs-style key bindings