### PR TITLE
replace shallowCopy with move

### DIFF
--- a/noise.nim
+++ b/noise.nim
@@ -276,10 +276,10 @@ when promptPreloadBuffer:
       truncated = true
       temp.setLen(PROMPT_MAX_LINE - 1)
 
-    shallowCopy(self.preloadText, temp)
+    self.preloadText = move temp
     if truncated:
       self.preloadError.add " [Edited line: the line length was reduced from "
-      self.preloadError.add "$1 to $1\n" % [$temp.len, $(PROMPT_MAX_LINE - 1)]
+      self.preloadError.add "$1 to $1\n" % [$self.preloadText.len, $(PROMPT_MAX_LINE - 1)]
 
 when promptKill:
   proc killSetMaxLen*(self: var Noise, len: int) =


### PR DESCRIPTION
Hello, `shallowCopy` has been removed for ARC/ORC since it does a deep copy with ARC/ORC → https://github.com/nim-lang/Nim/pull/20070

ref https://github.com/nim-lang/Nim/pull/19972