### PR TITLE
fix additional ',' in case statement

### DIFF
--- a/noise/editorImpl.nim
+++ b/noise/editorImpl.nim
@@ -199,7 +199,7 @@ when promptHistory:
     of ctrlChar('P'), UP_ARROW_KEY:
       # ctrl-P, recall Prev line in history
       historyAction(moveUp)
-    of ctrlChar('N'),  DOWN_ARROW_KEY, :
+    of ctrlChar('N'),  DOWN_ARROW_KEY:
       # ctrl-N, recall next line in history
       historyAction(moveDown)
     of ctrlChar('R'), ctrlChar('S'):


### PR DESCRIPTION
While trying to fix a bug in the Nim parser (https://github.com/nim-lang/Nim/pull/20930), the CI encountered this existing minor thing here. 

