### PR TITLE
Switch word editing progs to classic emacs behavior

### DIFF
--- a/noise/lineImpl.nim
+++ b/noise/lineImpl.nim
@@ -362,12 +362,8 @@ when promptCompletion:
 when promptWordEditing:
   import unicode
   proc findWord(self: var Line) =
-    if isAlphaNum(self.data[self.pos]):
-      # cursor under a word, move to left
-      while self.pos > 0 and isAlphaNum(self.data[self.pos - 1]):
-        dec self.pos
-    else:
-      # cursor under something else, move to next word
+    if not isAlphaNum(self.data[self.pos]):
+      # cursor not under word, move to next word
       while self.pos < self.dataLen and not isAlphaNum(self.data[self.pos]):
         inc self.pos
 


### PR DESCRIPTION
In case you want to go this way, this makes the behavior as defined in #28 the default.